### PR TITLE
Update versions according to yaml-file

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
-    version: 1.2.1
+    version: 1.2.2
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
@@ -10,7 +10,7 @@ shards:
 
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
-    version: 0.2.2
+    version: 0.3.0
 
   host_meta:
     git: https://github.com/toddsundsted/host_meta.git
@@ -18,11 +18,7 @@ shards:
 
   kemal:
     git: https://github.com/kemalcr/kemal.git
-    version: 1.1.2
-
-  kilt:
-    git: https://github.com/jeromegn/kilt.git
-    version: 0.6.1
+    version: 1.3.0
 
   libxml_ext:
     git: https://github.com/toddsundsted/libxml_ext.git
@@ -38,7 +34,7 @@ shards:
 
   school:
     git: https://github.com/toddsundsted/school.git
-    version: 0.1.0+git.commit.bf0034ca5a1bb2336650223b27b7e6aba51fe5ad
+    version: 0.2.0
 
   slang:
     git: https://github.com/toddsundsted/slang.git
@@ -46,7 +42,7 @@ shards:
 
   spectator:
     git: https://gitlab.com/arctic-fox/spectator.git
-    version: 0.10.5
+    version: 0.10.6
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git


### PR DESCRIPTION
Fixes #36.

`shard.lock` wasn't properly updated in the `dist` branch and requires `shards update` when building. This updates the existing `shards.lock` to the required versions