### PR TITLE
Allow HTTP 303 for searches (for GoToSocial)

### DIFF
--- a/src/framework/open.cr
+++ b/src/framework/open.cr
@@ -11,7 +11,7 @@ module Ktistec
         case response.status_code
         when 200
           return yield response
-        when 301, 302, 307, 308
+        when 301, 302, 303, 307, 308
           if (tmp = response.headers["Location"]?) && (url = tmp)
             next
           else


### PR DESCRIPTION
When searching for an URL that runs GoToSocial, they're actually forwarding with 303. I only observed this in one instance, but I doubt it's configurable and I think this should be safe enough to allow.

I don't want to link to someone's instance just for this example but here are the details via curl:
```
$ curl -v https://example.org/users/example1

< HTTP/2 303
< content-type: text/html; charset=utf-8
< location: /@example1
< permissions-policy: interest-cohort=()
< server: gotosocial
```