### PR TITLE
Allow searches for @user@host

### DIFF
--- a/src/controllers/searches.cr
+++ b/src/controllers/searches.cr
@@ -12,6 +12,7 @@ class SearchesController
     actor_or_object = nil
 
     if (query = env.params.query["query"]?)
+      query = query.strip()
       url = URI.parse(query)
       url =
         if url.scheme && url.host && url.path

--- a/src/controllers/searches.cr
+++ b/src/controllers/searches.cr
@@ -17,6 +17,9 @@ class SearchesController
         if url.scheme && url.host && url.path
           query
         else
+          if query.starts_with?("@")
+            query = query[1..]
+          end
           WebFinger.query("acct:#{query}").link("self").href.not_nil!
         end
       actor_or_object =


### PR DESCRIPTION
This is a minor nitpick, but the Mastodon search field accepts @user@host (and I think it also promotes this by displaying it this way on people's profile).

I am not sure if it's really a Mastodon-only thing, but it seems to be widespread enough that I've had to do it for 50% of the people who posted their fedi handles on Twitter.