### PR TITLE
Link to remote id in the instance from Actor cards and panels

### DIFF
--- a/src/views/partials/actor-card.html.slang
+++ b/src/views/partials/actor-card.html.slang
@@ -14,8 +14,10 @@
       .extra.content
         p == s summary
   .extra.content
-    a.left.floated href=actor.iri
+    a.left.floated href=remote_actor_path(actor)
       .meta= actor.display_name
+    br
+    a.left.floated href=actor.iri
       .meta= actor.account_uri
     - if (_account = env.account?) && _account.actor != actor
       - if env.request.path =~ /followers$/ && actor.follows?(_account.actor, confirmed: false) && (_follow = ActivityPub::Activity::Follow.follows?(actor, _account.actor))

--- a/src/views/partials/actor-panel.html.slang
+++ b/src/views/partials/actor-panel.html.slang
@@ -13,7 +13,7 @@
       - else
         i.user.icon
     .ui.segment
-      = actor.display_name
+      a href=remote_actor_path(actor) = actor.display_name
       br: a href=actor.display_link = actor.account_uri
       - if (summary = actor.summary.presence)
         br: == s summary


### PR DESCRIPTION
This is a fix for #35 It adds a link to the actors name that links to the page in the current instance in Following, Followers and Homepage