### PR TITLE
Support Mastodon-style Actor Profile Attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ Once these steps are done, you're running!
 
 <img src="https://raw.githubusercontent.com/toddsundsted/ktistec/main/images/o0ton2.png" width=640>
 
+## Running Tests
+
+The tests require that you set the `KEMAL_ENV` environment variable
+before running them, or they will lock up. Running the tests is:
+
+```
+KEMAL_ENV=test crystal spec
+```
+
 ## Contributors
 
 - [Todd Sundsted](https://github.com/toddsundsted) - creator and maintainer

--- a/spec/controllers/settings_spec.cr
+++ b/spec/controllers/settings_spec.cr
@@ -107,6 +107,14 @@ Spectator.describe SettingsController do
           post "/settings/actor", headers, "icon=%2Ffoo%2Fbar%2Fbaz"
           expect(ActivityPub::Actor.find(actor.id).icon).to eq("https://test.test/foo/bar/baz")
         end
+
+        it "updates the attachments" do
+          post "/settings/actor", headers, "attachment_0_name=Blog&attachment_0_value=https://beowulf.example.com"
+          attachments = ActivityPub::Actor.find(actor.id).attachments.not_nil!
+          expect(attachments.size).to eq(1)
+          expect(attachments.first.name).to eq("Blog")
+          expect(attachments.first.value).to eq("https://beowulf.example.com")
+        end
       end
 
       context "and posting JSON data" do
@@ -140,6 +148,14 @@ Spectator.describe SettingsController do
         it "updates the icon" do
           post "/settings/actor", headers, %q|{"icon":"/foo/bar/baz"}|
           expect(ActivityPub::Actor.find(actor.id).icon).to eq("https://test.test/foo/bar/baz")
+        end
+
+        it "updates the attachments" do
+          post "/settings/actor", headers, %q|{"attachment_0_name":"Blog","attachment_0_value":"https://beowulf.example.com"}|
+          attachments = ActivityPub::Actor.find(actor.id).attachments.not_nil!
+          expect(attachments.size).to eq(1)
+          expect(attachments.first.name).to eq("Blog")
+          expect(attachments.first.value).to eq("https://beowulf.example.com")
         end
       end
     end

--- a/spec/framework/util_spec.cr
+++ b/spec/framework/util_spec.cr
@@ -54,6 +54,12 @@ Spectator.describe Ktistec::Util do
       expect(described_class.sanitize(content)).to eq("<img src='https://test.test/pic.jpg' alt='picture' class='ui image' loading='lazy'>")
     end
 
+    # for presentation of mastodon compatible profile metadata
+    it "preserves 'invisible' in class attribute on span elements" do
+      content = "<span class='invisible foo bar'>a span</span>"
+      expect(described_class.sanitize(content)).to eq("<span class='invisible'>a span</span>")
+    end
+
     it "doesn't corrupt element order" do
       content = "<figure></figure><p></p>"
       expect(described_class.sanitize(content)).to eq("<figure></figure><p></p>")

--- a/src/assets/css/main.less
+++ b/src/assets/css/main.less
@@ -154,6 +154,18 @@ body { display: flex; flex-direction: column; }
         line-height: 5rem;
         font-size: 5rem;
     }
+    > .segment th {
+        border-right: 1px solid #22242626;
+        text-align: right;
+        font-weight: normal;
+        padding-right: 1ex;
+        margin-right: 1ex;
+    }
+    > .segment td {
+        text-align: left;
+        font-weight: normal;
+        padding-left: 1ex;
+    }
 }
 
 /** small actor partial **/

--- a/src/assets/css/main.less
+++ b/src/assets/css/main.less
@@ -277,3 +277,12 @@ trix-editor {
 
     figure img { object-fit: cover; width: 100%; height: auto; }
 }
+
+/** from mastodon **/
+.invisible {
+    font-size: 0;
+    line-height: 0;
+    display: inline-block;
+    width: 0;
+    height: 0;
+}

--- a/src/controllers/settings.cr
+++ b/src/controllers/settings.cr
@@ -78,7 +78,22 @@ class SettingsController
       "image" => params["image"]?.try(&.to_s.presence).try { |path| "#{host}#{path}" },
       "icon" => params["icon"]?.try(&.to_s.presence).try { |path| "#{host}#{path}" },
       "footer" => params["footer"]?.try(&.to_s.presence),
-      "site" => params["site"]?.try(&.to_s.presence)
+      "site" => params["site"]?.try(&.to_s.presence),
+      "attachments" => reduce_attachments(params)
     }.compact
+  end
+
+  private def self.reduce_attachments(params)
+    0.upto(ActivityPub::Actor::ATTACHMENT_LIMIT - 1).reduce(Array(ActivityPub::Actor::Attachment).new) do |memo, i|
+      if params["attachment_#{i}_name"]?.try(&.to_s.presence) &&
+          params["attachment_#{i}_value"]?.try(&.to_s.presence)
+        memo << ActivityPub::Actor::Attachment.new(
+          params["attachment_#{i}_name"].to_s,
+          "PropertyValue",
+          params["attachment_#{i}_value"].to_s
+        )
+      end
+      memo
+    end
   end
 end

--- a/src/database/migrations/000022-add-attachments-to-actors.cr
+++ b/src/database/migrations/000022-add-attachments-to-actors.cr
@@ -1,0 +1,11 @@
+require "../../framework/database"
+
+extend Ktistec::Database::Migration
+
+up do |db|
+  add_column "actors", "attachments", "text"
+end
+
+down do |db|
+  remove_column "actors", "attachments"
+end

--- a/src/framework/framework.cr
+++ b/src/framework/framework.cr
@@ -61,9 +61,9 @@ module Ktistec
     end
 
     def assign(options)
-      @host = options["host"] if options.has_key?("host")
-      @site = options["site"] if options.has_key?("site")
-      @footer = options["footer"] if options.has_key?("footer")
+      @host = options["host"].as(String) if options.has_key?("host")
+      @site = options["site"].as(String) if options.has_key?("site")
+      @footer = options["footer"].as(String?) if options.has_key?("footer")
       self
     end
 

--- a/src/framework/util.cr
+++ b/src/framework/util.cr
@@ -54,6 +54,9 @@ module Ktistec
       img: {
         keep: ["src", "alt"],
         all: [{"class", "ui image"}, {"loading", "lazy"}]
+      },
+      span: {
+        class: ["invisible"]
       }
     }
 
@@ -75,8 +78,14 @@ module Ktistec
       elsif html.element? && name.in?(ELEMENTS)
         if (attributes = ATTRIBUTES[name]?)
           build << "<" << name
-          (attributes[:keep] & html.attributes.map(&.name)).each do |attribute|
-            build << " #{attribute}='#{html[attribute]}'"
+          if (keep = attributes[:keep]?)
+            (keep & html.attributes.map(&.name)).each do |attribute|
+              build << " #{attribute}='#{html[attribute]}'"
+            end
+          end
+          if (classes = attributes[:class]?) && (class_attribute = html.attributes["class"]?)
+            classes = (classes & class_attribute.content.split).join(' ')
+            build << " class='#{classes}'" if classes.presence
           end
           local =
             if (key = attributes[:key]?) && (value = html.attributes[key]?)

--- a/src/views/actors/actor.json.ecr
+++ b/src/views/actors/actor.json.ecr
@@ -1,7 +1,12 @@
 {
   "@context":[
     "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/security/v1"
+    "https://w3id.org/security/v1",
+    {
+      "schema":"http://schema.org#",
+      "PropertyValue":"schema:PropertyValue",
+      "value":"schema:value"
+    }
   ],
   <%- if (username = actor.username) -%>
   "preferredUsername":<%= username.inspect %>,
@@ -49,6 +54,15 @@
     "type":"Image",
     "url":<%= image.inspect %>
   },
+  <%- end -%>
+  <%- if (attachments = actor.attachments) -%>
+  "attachment":[
+    <%- attachments.each.with_index do |attachment, i| %> {
+    "type":<%= attachment.type.inspect %>,
+    "name":<%= attachment.name.inspect %>,
+    "value":<%= actor.class.maybe_wrap_link(attachment.value).inspect %>
+    }<%= i < attachments.size - 1 ? "," : "" %><%- end -%>
+  ],
   <%- end -%>
   <%- if (urls = actor.urls) -%>
   <%- if urls.size > 1 -%>

--- a/src/views/partials/actor-panel.html.slang
+++ b/src/views/partials/actor-panel.html.slang
@@ -17,6 +17,13 @@
       br: a href=actor.display_link = actor.account_uri
       - if (summary = actor.summary.presence)
         br: == s summary
+      - if (attachments = actor.attachments.presence)
+        .ui.divider
+        table
+          - attachments.each do |attachment|
+            tr
+              th.name == attachment.name
+              td.value == maybe_wrap_link(attachment.value)
   - if (_account = env.account?) && _account.actor != actor
     .ui.basic.segment
       - if (_follow = ActivityPub::Activity::Follow.follows?(_account.actor, actor))

--- a/src/views/partials/actor-panel.html.slang
+++ b/src/views/partials/actor-panel.html.slang
@@ -22,8 +22,8 @@
         table
           - attachments.each do |attachment|
             tr
-              th.name == attachment.name
-              td.value == maybe_wrap_link(attachment.value)
+              th.name = attachment.name
+              td.value == s maybe_wrap_link(attachment.value)
   - if (_account = env.account?) && _account.actor != actor
     .ui.basic.segment
       - if (_follow = ActivityPub::Activity::Follow.follows?(_account.actor, actor))

--- a/src/views/settings/settings.html.slang
+++ b/src/views/settings/settings.html.slang
@@ -12,6 +12,25 @@ p
   == input_tag("Summary", actor, summary)
   == input_tag("Timezone", account, timezone, data: {"controller" => "local-timezone"})
   == input_tag("Password", account, password, type: "password", placeholder: "Leave blank to leave unchanged")
+  crystal:
+    attachments = actor.attachments || [] of ActivityPub::Actor::Attachment
+    attachments.size.upto(ActivityPub::Actor::ATTACHMENT_LIMIT - 1) do |i|
+      attachments << ActivityPub::Actor::Attachment.new("", "", "")
+    end
+  .field
+    label Metadata
+    p You can have up to four items displayed on your profile.
+  .two.fields
+    .field
+      label Name
+    .field
+      label Value
+  - 0.upto(ActivityPub::Actor::ATTACHMENT_LIMIT - 1).each do |i|
+    .two.fields
+      .field
+        input type="text" name="attachment_#{i}_name" value=attachments[i].name
+      .field
+        input type="text" name="attachment_#{i}_value" value=attachments[i].value
   == input_tag("Background Image", actor, image, class: "filepond", type: "file")
   == input_tag("Profile Image", actor, icon, class: "filepond", type: "file")
   input.ui.primary.button type="submit" value="Update"

--- a/src/views/view_helper.cr
+++ b/src/views/view_helper.cr
@@ -35,6 +35,24 @@ module Ktistec::ViewHelper
       page = (p = query["page"]?) && (p = p.to_i) > 0 ? p : 1
       render "./src/views/partials/paginator.html.slang"
     end
+
+    def maybe_wrap_link(str)
+      if str =~ %r{^[a-zA-Z0-9]+://}
+        uri = URI.parse(str)
+        port = uri.port.nil? ? "" : ":" + uri.port.to_s
+        path = uri.path.nil? ? "" : uri.path.to_s
+
+        # Match the weird format used by Mastodon here
+        <<-LINK.gsub(/(\n|^ +)/, "")
+        <a href="#{str}" target="_blank" rel="nofollow noopener noreferrer me">
+          <span class="invisible">#{uri.scheme}://</span><span class="">#{uri.host}#{port}#{path}</span>
+          <span class="invisible"></span>
+        </a>
+        LINK
+      else
+        str
+      end
+    end
   end
 
   macro included


### PR DESCRIPTION
@relistan this PR replaces https://github.com/toddsundsted/ktistec/pull/51. i squashed the commits to clean up the history. i also made a few small changes. the main one: i removed a debugging puts (p), i tweaked the styling—semantic already supported the necessary styling for the settings form, and i removed some changes to specs that were no longer necessary for this changeset. i also tacked on two additional commits of my own: one to run sanitization on html values, which required updates to my sanitization code, but which will prevent javascript code injection; and another to style the "invisible" class supplied on the attachment values to hide parts of a URL, as mastodon does, which looks pretty slick imo.

one caveat unrelated to your changes that you'll have to deal with. by the time this was merged, there was already another migration with the same number in the commit history. migrations are deemed applied (or pending) using the number only (not the name). to deal with this i had to renumber your migration. as a consequence, if you roll out these changes, it will attempt to add the column again and the migration will fail. the simplest thing is to revert your migration that adds the attachments column before you build and deploy this. i'm happy to assist if you run into problem or want to talk over alternative approaches. (going forward i will switch to timestamps)

i very very much appreciate you implementing this! i plan to deploy this myself today! thank you!