### PR TITLE
set application name in webmanifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Ktistec",
+    "short_name": "Ktistec",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
Sets a name in the [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest). If both strings are empty, this results in the shortcut of the SSB (e.g. on Android) to be named "Website" or any other generic name.