### PR TITLE
Fix docker build issue #79 by using crystallang/crystal:latest-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.2.2-alpine AS builder
+FROM crystallang/crystal:latest-alpine AS builder
 RUN apk update && apk upgrade && apk add sqlite-static
 WORKDIR /build/
 ARG version


### PR DESCRIPTION
Fix docker build issue #79 by using crystallang/crystal:latest-alpine as builder base image