### PR TITLE
Update Dockerfile for 2.0.0 and always build assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG version
 RUN git clone --branch ${version:-v2.0.0} --depth 1 https://github.com/toddsundsted/ktistec .
 RUN shards update && shards install --production
 RUN crystal build src/ktistec/server.cr --static --no-debug --release
+RUN apk add npm
+RUN npm install --save-dev webpack
+RUN npm run build
 
 FROM alpine:latest AS server
 RUN apk --no-cache add tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM crystallang/crystal:latest-alpine AS builder
 RUN apk update && apk upgrade && apk add sqlite-static
 WORKDIR /build/
 ARG version
-RUN git clone --branch ${version:-v2.0.0-10} --depth 1 https://github.com/toddsundsted/ktistec .
+RUN git clone --branch ${version:-v2.0.0} --depth 1 https://github.com/toddsundsted/ktistec .
 RUN shards update && shards install --production
 RUN crystal build src/ktistec/server.cr --static --no-debug --release
 


### PR DESCRIPTION
1. Sets the default version within the Dockerfile to the newly released 2.0.0 version
2. always (re-)builds assets
  * This only takes two additional packages: `npm` and `webpack` in the `build` container, nothing changes for the deployment container, whatsoever
  * Build-time is only a few seconds and unnoticeable compared to building ktistec itself
  * assets are always available, whatever branch you are building from