### PR TITLE
Build docker images automatically

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
       # build ktistec using the version of the current tag
       - name: Build and push docker image
         id: push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,57 @@
+# run continuous deployment pipeline on every push on a tag in the form "v0.0.0"
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+# deploy to github's image registry
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# run build-and-push job on an ubuntu host
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+
+    steps:       
+    
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Gather docker meta information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha    
+
+      # build ktistec using the version of the current tag
+      - name: Build and push docker image
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            version=v${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM crystallang/crystal:latest-alpine AS builder
 RUN apk update && apk upgrade && apk add sqlite-static
 WORKDIR /build/
 ARG version
-RUN git clone --branch ${version:-v2.3.0} --depth 1 https://github.com/toddsundsted/ktistec .
+RUN git clone --branch ${version:-main} --depth 1 https://github.com/toddsundsted/ktistec .
 RUN shards update && shards install --production
 RUN crystal build src/ktistec/server.cr --static --no-debug --release
 RUN apk add npm


### PR DESCRIPTION
This PR creates a CD workflow that will build a new docker-image for every push to a `tag` (including the creation of a tag) in the form of `v1.2.3`.

The images will be pushed to the github registry of this repository with the image tags taken from the git tag (i.e. for the major `1`, the major-minor `1.2`, the major-minor-patch `1.2.3` as well as the `latest` tag.

The `Dockerfile` will by default build from the `main` branch, which makes development easier in a docker-workflow. The CD however will always use the tag as build-arg.

This is my first github-workflow (I did write many gitlab CI/CD pipelines). Information was taken from https://github.com/docker/build-push-action & https://github.com/docker/metadata-action

I did test this CD in my own fork: https://github.com/JayVii/ktistec/actions & https://github.com/JayVii/ktistec/tree/test_actions

I did testing builds (some with fake versions and some with proper) that have been pushed here: https://github.com/JayVii/ktistec/pkgs/container/ktistec