### PR TITLE
Build containers for arm64 as well as amd64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Temporary, for demonstration purposes
+  pull_request:
 
 # deploy to github's image registry
 env:
@@ -53,5 +55,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             version=v${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}


### PR DESCRIPTION
The current container builds use `docker buildx build`, which allows multi-platform builds. Since `platform` isn't being specified, it uses the [default platform list](https://github.com/toddsundsted/ktistec/actions/runs/12620035266/job/35165261450#step:5:165):

```
"platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/386"
```

In practice, I've only found `linux/amd64,linux/arm64` necessary. I'm not sure the `amd64/v2`, `amd64/v3`, or `386` images are doing anything for these builds anyway. Multi-platform images on GHCR generally have an `OS/Arch` tab. For example, in [my `rails-app-operator`](https://github.com/jgaskins/rails_app_operator/pkgs/container/rails-app-operator):

<img width="781" alt="image" src="https://github.com/user-attachments/assets/1ab8f216-4874-4e94-ac65-6e507b9c5084" />

Ktistec's container builds don't have that tab, so I'm not sure those other platforms are actually being used:

<img width="783" alt="image" src="https://github.com/user-attachments/assets/0ee8560e-b38c-4407-94ff-fe622ff611c4" />

For the purposes of demonstrating the builds before the next tagged release, I've also added a `pull_request` event handler so it can work on this PR. We can either remove that before merging or leave it in place to be able to test Ktistec on PRs trivially with `docker run`.