### PR TITLE
Crystal Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
     - [OAuth](#oauth)
   - [Prerequisites](#prerequisites)
   - [Building](#building)
+    - [Crystal Compatibility](#crystal-compatibility)
     - [SQLite3 Compatibility](#sqlite3-compatibility)
     - [Running Tests](#running-tests)
   - [Setup, Configuration, and Usage](#setup-configuration-and-usage)
@@ -964,8 +965,8 @@ by (and content is addressed to) a username and a hostname.
 
 You must compile the Ktistec server executable from its source code.
 You will need to install a recent release of the [Crystal programming
-language](https://crystal-lang.org/install/)
-(but see notes on [Crystal compatibility](#crystal-compatibility)).
+language](https://crystal-lang.org/install/) (but see notes on
+[Crystal compatibility](#crystal-compatibility)).
 
 Ktistec requires at least SQLite3 version 3.35.0 (but see notes
 on [Sqlite3 compatibility](#sqlite3-compatibility)).
@@ -1010,7 +1011,9 @@ problems for Ktistec:
 
 | Crystal Version | Issue |
 |--|--|
-| 1.20.0 | problems with macros [link](https://github.com/crystal-lang/crystal/issues/16891)
+| 1.17.0 - 1.18.2 | libxml memory management [link](https://github.com/crystal-lang/crystal/pull/15906) |
+| 1.20.0 | macros changes [link](https://github.com/crystal-lang/crystal/issues/16891) |
+| 1.20.0 | OpenSSL changes [link](https://github.com/crystal-lang/crystal/pull/16640) |
 
 ### SQLite3 Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,7 @@ You can now connect to and configure the server.
 
 ### Crystal Compatibility
 
-The following Crystal versions are known to have bugs that cause
+The following Crystal versions are known to have issues that cause
 problems for Ktistec:
 
 | Crystal Version | Issue |

--- a/README.md
+++ b/README.md
@@ -964,8 +964,11 @@ by (and content is addressed to) a username and a hostname.
 
 You must compile the Ktistec server executable from its source code.
 You will need to install a recent release of the [Crystal programming
-language](https://crystal-lang.org/install/). Ktistec requires at least
-SQLite3 version 3.35.0 (but see notes on [Sqlite3 compatibility](#sqlite3-compatibility)).
+language](https://crystal-lang.org/install/)
+(but see notes on [Crystal compatibility](#crystal-compatibility)).
+
+Ktistec requires at least SQLite3 version 3.35.0 (but see notes
+on [Sqlite3 compatibility](#sqlite3-compatibility)).
 
 To obtain the source code, clone the [Ktistec Github
 repo](https://github.com/toddsundsted/ktistec).
@@ -999,6 +1002,15 @@ something like:
 `Ktistec is ready to lead at http://0.0.0.0:3000`
 
 You can now connect to and configure the server.
+
+### Crystal Compatibility
+
+The following Crystal versions are known to have bugs that cause
+problems for Ktistec:
+
+| Crystal Version | Issue |
+|--|--|
+| 1.20.0 | problems with macros [link](https://github.com/crystal-lang/crystal/issues/16891)
 
 ### SQLite3 Compatibility
 


### PR DESCRIPTION
I was unable to build ktistec using crystal 1.20.0.
Found the relevant bug: https://github.com/crystal-lang/crystal/issues/16891
and added it to the ktistec README